### PR TITLE
Add Play Count & Playlist Index columns

### DIFF
--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -151,11 +151,16 @@ export default function Transfer() {
           </Tooltip>
         );
 
+        let playcount = importedPlaylist[id].playcount;
+        let playlistindex = importedPlaylist[id].playlistindex;
+
         return {
           id,
           status,
           ...selectedSong,
           title,
+          playcount,
+          playlistindex,
         };
       }
 
@@ -223,11 +228,13 @@ export default function Transfer() {
             .then((items) => {
               const songs = appendConfidenceLevel(
                 importedPlaylist[id],
-                items.map(({ uri, artists, album, name }) => ({
+                items.map(({ uri, artists, album, name, playcount, playlistindex }) => ({
                   uri,
                   artist: artists[0].name,
                   album: album.name,
                   title: name,
+                  playcount: playcount,
+                  playlistindex: playlistindex,
                 }))
               );
 

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -27,7 +27,7 @@ export default function Transfer() {
   const { store: spotifyState, dispatch: spotifyDispatch } = spotifyContext;
   const { importedPlaylists, searchResults, selectedSongs, selectedPlaylist } = spotifyState;
 
-  const [sortColumn, setSortColumn] = useState<'title' | 'artist' | 'album' | 'confidence'>(
+  const [sortColumn, setSortColumn] = useState<'title' | 'artist' | 'album' | 'playcount' | 'playlistindex' | 'confidence'>(
     'title'
   );
   const [isLoading, setIsLoading] = useState(false);
@@ -175,6 +175,10 @@ export default function Transfer() {
           return a.artist > b.artist ? 1 : -1;
         case 'album':
           return a.album > b.album ? 1 : -1;
+        case 'playlistindex':
+          return a.playlistindex > b.playlistindex ? 1 : -1;
+        case 'playcount':
+          return a.playcount < b.playcount ? 1 : -1;
         case 'title':
         default:
           // a.title could be a react component
@@ -405,6 +409,16 @@ export default function Transfer() {
           <Table.Column prop="album">
             <span className={styles.tableHeader} onClick={() => setSortColumn('album')}>
               {'Album'}
+            </span>
+          </Table.Column>
+          <Table.Column prop="playcount">
+            <span className={styles.tableHeader} onClick={() => setSortColumn('playcount')}>
+              {'Play Count'}
+            </span>
+          </Table.Column>
+          <Table.Column prop="playlistindex">
+            <span className={styles.tableHeader} onClick={() => setSortColumn('playlistindex')}>
+              {'Playlist Index'}
             </span>
           </Table.Column>
           {!!spotifyPlaylistKeys.length && (

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -27,9 +27,9 @@ export default function Transfer() {
   const { store: spotifyState, dispatch: spotifyDispatch } = spotifyContext;
   const { importedPlaylists, searchResults, selectedSongs, selectedPlaylist } = spotifyState;
 
-  const [sortColumn, setSortColumn] = useState<'title' | 'artist' | 'album' | 'playcount' | 'playlistindex' | 'confidence'>(
-    'title'
-  );
+  const [sortColumn, setSortColumn] = useState<
+    'title' | 'artist' | 'album' | 'playcount' | 'playlistindex' | 'confidence'
+  >('title');
   const [isLoading, setIsLoading] = useState(false);
   const [isTransferringPlaylist, setTransferringPlaylist] = useState(false);
   const [transferredPlaylists, setTransferredPlaylists] = useState<string[]>([]);
@@ -228,7 +228,7 @@ export default function Transfer() {
             .then((items) => {
               const songs = appendConfidenceLevel(
                 importedPlaylist[id],
-                items.map(({ uri, artists, album, name, playcount, playlistindex }) => ({
+                (items as any[]).map(({ uri, artists, album, name, playcount, playlistindex }) => ({
                   uri,
                   artist: artists[0].name,
                   album: album.name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,8 @@ export type Song = {
   title: string;
   confidence?: string;
   uri?: string;
-  playcount?: number;
-  playlistindex?: number;
+  playcount: number;
+  playlistindex: number;
 };
 
 export type Playlist = { [importId: string]: Song };

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export type Song = {
   title: string;
   confidence?: string;
   uri?: string;
+  playcount?: number;
+  playlistindex?: number;
 };
 
 export type Playlist = { [importId: string]: Song };

--- a/src/utility/parse-playlists.ts
+++ b/src/utility/parse-playlists.ts
@@ -47,7 +47,7 @@ export function findAndParseCsvs(entry: any): Promise<any[]> {
                       entry.file((file: File) => {
                         parse(file, {
                           header: true,
-                          complete: (r) => {
+                          complete: (r: any) => {
                             // Reassign properties to names that don't contain spaces
                             // There's probably a better way to reference these columns in
                             // songArrayReducer which doesn't require this, but I don't know it.

--- a/src/utility/parse-playlists.ts
+++ b/src/utility/parse-playlists.ts
@@ -7,17 +7,21 @@ export function flattenArray<T>(arr: any[]): T[] {
 }
 
 export function songArrayReducer(acc: any, next: any) {
-  const decodeChars = (str: string) =>  str.replace(/\&#39;/g, '\'')
-    .replace(/\&quot;/g, '"').replace(/\&amp;/g, '&')
-    .replace(/\&lt;/g, '<').replace(/\&gt;/g, '>');
+  const decodeChars = (str: string) =>
+    str
+      .replace(/\&#39;/g, "'")
+      .replace(/\&quot;/g, '"')
+      .replace(/\&amp;/g, '&')
+      .replace(/\&lt;/g, '<')
+      .replace(/\&gt;/g, '>');
   const playlistName = Object.keys(next)[0];
-  const { Album, Artist, Title, PlayCount, PlaylistIndex} = next[playlistName];
-  if (Album != null && Artist != null && Title != null && PlayCount != null && PlaylistIndex != null) {
+  const { Album, Artist, Title, PlayCount, PlaylistIndex } = next[playlistName];
+  if (Album != null && Artist != null && Title != null) {
     const album = decodeChars(Album);
     const artist = decodeChars(Artist);
     const title = decodeChars(Title).replace(/"/g, '');
-    const playcount = parseInt(PlayCount);
-    const playlistindex = parseInt(PlaylistIndex);
+    const playcount = PlayCount && parseInt(PlayCount);
+    const playlistindex = PlaylistIndex && parseInt(PlaylistIndex);
     if (!acc[playlistName]) {
       acc[playlistName] = { 0: { album, artist, title, playcount, playlistindex } };
     } else {
@@ -51,8 +55,8 @@ export function findAndParseCsvs(entry: any): Promise<any[]> {
                             // Reassign properties to names that don't contain spaces
                             // There's probably a better way to reference these columns in
                             // songArrayReducer which doesn't require this, but I don't know it.
-                            r.data[0]["PlayCount"] = r.data[0]["Play Count"];
-                            r.data[0]["PlaylistIndex"] = r.data[0]["Playlist Index"];
+                            r.data[0]['PlayCount'] = r.data[0]['Play Count'];
+                            r.data[0]['PlaylistIndex'] = r.data[0]['Playlist Index'];
 
                             res({ [playlist]: r.data[0] });
                           },

--- a/src/utility/parse-playlists.ts
+++ b/src/utility/parse-playlists.ts
@@ -19,7 +19,7 @@ export function songArrayReducer(acc: any, next: any) {
     const playcount = parseInt(PlayCount);
     const playlistindex = parseInt(PlaylistIndex);
     if (!acc[playlistName]) {
-      acc[playlistName] = { 0: { album, artist, title, playcount } };
+      acc[playlistName] = { 0: { album, artist, title, playcount, playlistindex } };
     } else {
       const numSongs = Object.keys(acc[playlistName]).length;
       acc[playlistName][numSongs] = { album, artist, title, playcount, playlistindex };

--- a/src/utility/parse-playlists.ts
+++ b/src/utility/parse-playlists.ts
@@ -11,16 +11,18 @@ export function songArrayReducer(acc: any, next: any) {
     .replace(/\&quot;/g, '"').replace(/\&amp;/g, '&')
     .replace(/\&lt;/g, '<').replace(/\&gt;/g, '>');
   const playlistName = Object.keys(next)[0];
-  const { Album, Artist, Title } = next[playlistName];
-  if (Album != null && Artist != null && Title != null) {
+  const { Album, Artist, Title, PlayCount, PlaylistIndex} = next[playlistName];
+  if (Album != null && Artist != null && Title != null && PlayCount != null && PlaylistIndex != null) {
     const album = decodeChars(Album);
     const artist = decodeChars(Artist);
     const title = decodeChars(Title).replace(/"/g, '');
+    const playcount = parseInt(PlayCount);
+    const playlistindex = parseInt(PlaylistIndex);
     if (!acc[playlistName]) {
-      acc[playlistName] = { 0: { album, artist, title } };
+      acc[playlistName] = { 0: { album, artist, title, playcount } };
     } else {
       const numSongs = Object.keys(acc[playlistName]).length;
-      acc[playlistName][numSongs] = { album, artist, title };
+      acc[playlistName][numSongs] = { album, artist, title, playcount, playlistindex };
     }
   }
 
@@ -46,6 +48,12 @@ export function findAndParseCsvs(entry: any): Promise<any[]> {
                         parse(file, {
                           header: true,
                           complete: (r) => {
+                            // Reassign properties to names that don't contain spaces
+                            // There's probably a better way to reference these columns in
+                            // songArrayReducer which doesn't require this, but I don't know it.
+                            r.data[0]["PlayCount"] = r.data[0]["Play Count"];
+                            r.data[0]["PlaylistIndex"] = r.data[0]["Playlist Index"];
+
                             res({ [playlist]: r.data[0] });
                           },
                         });


### PR DESCRIPTION
I wanted to import some playlist with ordering from GPM / sorted by play count, so I hacked in those columns.

There's certainly a better way to refer to the `Play Count` and `Playlist Index` columns without having reassign them to `PlayCount` and `PlaylistIndex` respectively, but I don't know what that way is.